### PR TITLE
Minor CI pipeline cleanup

### DIFF
--- a/.aws/taskdefinition-nonprod.json
+++ b/.aws/taskdefinition-nonprod.json
@@ -1,5 +1,5 @@
 {
-    "taskDefinitionArn": "arn:aws:ecs:us-east-1:784431842911:task-definition/ruleslawyer-backend:18",
+    "taskDefinitionArn": "arn:aws:ecs:us-east-1:784431842911:task-definition/ruleslawyer-backend",
     "containerDefinitions": [
         {
             "name": "ruleslawyer-backend",
@@ -64,38 +64,6 @@
     "family": "ruleslawyer-backend",
     "executionRoleArn": "arn:aws:iam::784431842911:role/ecsTaskExecutionRole",
     "networkMode": "awsvpc",
-    "revision": 18,
-    "volumes": [],
-    "status": "ACTIVE",
-    "requiresAttributes": [
-        {
-            "name": "com.amazonaws.ecs.capability.logging-driver.awslogs"
-        },
-        {
-            "name": "ecs.capability.execution-role-awslogs"
-        },
-        {
-            "name": "com.amazonaws.ecs.capability.ecr-auth"
-        },
-        {
-            "name": "com.amazonaws.ecs.capability.docker-remote-api.1.19"
-        },
-        {
-            "name": "ecs.capability.secrets.asm.environment-variables"
-        },
-        {
-            "name": "ecs.capability.execution-role-ecr-pull"
-        },
-        {
-            "name": "com.amazonaws.ecs.capability.docker-remote-api.1.18"
-        },
-        {
-            "name": "ecs.capability.task-eni"
-        },
-        {
-            "name": "com.amazonaws.ecs.capability.docker-remote-api.1.29"
-        }
-    ],
     "placementConstraints": [],
     "compatibilities": [
         "EC2",

--- a/.github/workflows/aws-nonprod.yml
+++ b/.github/workflows/aws-nonprod.yml
@@ -1,42 +1,13 @@
-# This workflow will build and push a new container image to Amazon ECR,
-# and then will deploy a new task definition to Amazon ECS, when there is a push to the "main" branch.
-#
-# To use this workflow, you will need to complete the following set-up steps:
-#
-# 1. Create an ECR repository to store your images.
-#    For example: `aws ecr create-repository --repository-name my-ecr-repo --region us-east-2`.
-#    Replace the value of the `ECR_REPOSITORY` environment variable in the workflow below with your repository's name.
-#    Replace the value of the `AWS_REGION` environment variable in the workflow below with your repository's region.
-#
-# 2. Create an ECS task definition, an ECS cluster, and an ECS service.
-#    For example, follow the Getting Started guide on the ECS console:
-#      https://us-east-2.console.aws.amazon.com/ecs/home?region=us-east-2#/firstRun
-#    Replace the value of the `ECS_SERVICE` environment variable in the workflow below with the name you set for the Amazon ECS service.
-#    Replace the value of the `ECS_CLUSTER` environment variable in the workflow below with the name you set for the cluster.
-#
-# 3. Store your ECS task definition as a JSON file in your repository.
-#    The format should follow the output of `aws ecs register-task-definition --generate-cli-skeleton`.
-#    Replace the value of the `ECS_TASK_DEFINITION` environment variable in the workflow below with the path to the JSON file.
-#    Replace the value of the `CONTAINER_NAME` environment variable in the workflow below with the name of the container
-#    in the `containerDefinitions` section of the task definition.
-#
-# 4. Store an IAM user access key in GitHub Actions secrets named `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.
-#    See the documentation for each action used below for the recommended IAM policies for this IAM user,
-#    and best practices on handling the access key credentials.
-
 name: Deploy to Amazon ECS (NonProd)
 
 on: workflow_dispatch
 
 env:
-  AWS_REGION: us-east-1                   # set this to your preferred AWS region, e.g. us-west-1
-  ECR_REPOSITORY: ruleslawyer-backend           # set this to your Amazon ECR repository name
-  ECS_SERVICE: rules-lawyer-backend                 # set this to your Amazon ECS service name
-  ECS_CLUSTER: geekway-nonprod                # set this to your Amazon ECS cluster name
-  ECS_TASK_DEFINITION: .aws/taskdefinition-nonprod.json # set this to the path to your Amazon ECS task definition
-                                               # file, e.g. .aws/task-definition.json
-  CONTAINER_NAME: ruleslawyer-backend           # set this to the name of the container in the
-                                               # containerDefinitions section of your task definition
+  ECR_REPOSITORY: ruleslawyer-backend
+  ECS_SERVICE: rules-lawyer-backend
+  ECS_CLUSTER: geekway-nonprod
+  ECS_TASK_DEFINITION: .aws/taskdefinition-nonprod.json
+  CONTAINER_NAME: ruleslawyer-backend
 
 permissions:
   contents: read
@@ -56,7 +27,7 @@ jobs:
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        aws-region: ${{ env.AWS_REGION }}
+        aws-region: ${{ secrets.AWS_REGION }}
 
     - name: Login to Amazon ECR
       id: login-ecr

--- a/.github/workflows/aws-nonprod.yml
+++ b/.github/workflows/aws-nonprod.yml
@@ -26,10 +26,7 @@
 
 name: Deploy to Amazon ECS (NonProd)
 
-on:
-  push:
-    tags:
-      - "nonprod-*"
+on: workflow_dispatch
 
 env:
   AWS_REGION: us-east-1                   # set this to your preferred AWS region, e.g. us-west-1


### PR DESCRIPTION
* I removed what I think *might* unnecessary data from the task definition JSON. I think we don't need to specify the version number -  I think that only increments on the AWS side. 
* Updated AWS_REGION to come from org secrets instead of the GHA config section.
* I changed the deploy pipeline to only run on `workflow_dispatch`. This means that triggering a deploy is always a manual action for now. When you trigger the action, you can supply a branch, which means we can tweak the pipeline or deployment without pushing to main every time.