### PR TITLE
Don't log health checks

### DIFF
--- a/.aws/taskdefinition-nonprod.json
+++ b/.aws/taskdefinition-nonprod.json
@@ -69,7 +69,17 @@
                     "awslogs-stream-prefix": "ecs"
                 },
                 "secretOptions": []
-            }
+            },
+						"healthCheck": {
+							"command": [
+								"CMD-SHELL",
+								"curl -f https://localhost:8080/api/status || exit 1"
+							],
+							"interval": 30,
+							"retries": 3,
+							"startPeriod": 20,
+							"timeout": 5
+						}
         }
     ],
     "family": "ruleslawyer-backend",

--- a/.aws/taskdefinition-nonprod.json
+++ b/.aws/taskdefinition-nonprod.json
@@ -69,17 +69,7 @@
                     "awslogs-stream-prefix": "ecs"
                 },
                 "secretOptions": []
-            },
-						"healthCheck": {
-							"command": [
-								"CMD-SHELL",
-								"echo hello"
-							],
-							"interval": 10,
-							"retries": 5,
-							"startPeriod": 20,
-							"timeout": 5
-						}
+            }
         }
     ],
     "family": "ruleslawyer-backend",

--- a/.aws/taskdefinition-nonprod.json
+++ b/.aws/taskdefinition-nonprod.json
@@ -73,7 +73,7 @@
 						"healthCheck": {
 							"command": [
 								"CMD-SHELL",
-								"curl -f https://localhost:8080/api/status || exit 1"
+								"curl -f localhost:8080/api/status || exit 1"
 							],
 							"interval": 30,
 							"retries": 3,

--- a/.aws/taskdefinition-nonprod.json
+++ b/.aws/taskdefinition-nonprod.json
@@ -73,10 +73,10 @@
 						"healthCheck": {
 							"command": [
 								"CMD-SHELL",
-								"curl -f localhost:8080/api/status || exit 1"
+								"echo hello"
 							],
-							"interval": 30,
-							"retries": 3,
+							"interval": 10,
+							"retries": 5,
 							"startPeriod": 20,
 							"timeout": 5
 						}

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,12 +6,19 @@ import {
 } from '@nestjs/platform-fastify';
 import multipart from '@fastify/multipart';
 import { RuleslawyerLogger } from './utils/ruleslawyer.logger';
+import * as fastify from 'fastify';
 
 async function bootstrap() {
+	const fastifyInstance = fastify({logger: true});
+	fastifyInstance.addHook('onRoute', opts => {
+		if (opts.path === '/api/status') {
+			opts.logLevel = 'silent';
+		}
+	});
 	const logger = new RuleslawyerLogger('NESTJS');
   const app = await NestFactory.create<NestFastifyApplication>(
     AppModule, 
-		new FastifyAdapter({ logger: true }),
+		new FastifyAdapter(fastifyInstance),
 		{
 			logger: ['debug', 'error', 'fatal', 'log', 'verbose', 'warn']
 		}


### PR DESCRIPTION
We want Fastify logging HTTP requests, but since the load balancer hits the health check endpoint once a second, that's going to fill our logs with a bunch of garbage. This adds an `onRoute` hook that silences the logs for the health check endpoint.