### PR TITLE
Reduce ECS instance sizes

### DIFF
--- a/.aws/taskdefinition-nonprod.json
+++ b/.aws/taskdefinition-nonprod.json
@@ -80,8 +80,8 @@
     "requiresCompatibilities": [
         "FARGATE"
     ],
-    "cpu": "1024",
-    "memory": "3072",
+    "cpu": "256",
+    "memory": "512",
     "runtimePlatform": {
         "cpuArchitecture": "X86_64",
         "operatingSystemFamily": "LINUX"


### PR DESCRIPTION
CloudWatch metrics show that we're using a small percentage of the compute configured for each instance. This PR reduces the size of instance configured in the task definition.