### PR TITLE
Switching nonprod to the default environment in build/deploy workflow

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       environment: 
-        description: 'The environment to deploy to'
+        description: 'Choose a deployment environment'
         required: true
         default: 'nonprod'
         type: choice
@@ -18,7 +18,7 @@ env:
   ECS_CLUSTER: geekway-${{inputs.environment}}
   ECS_TASK_DEFINITION: .aws/taskdefinition-${{inputs.environment}}.json
   CONTAINER_NAME: ruleslawyer-backend
-  ROLE_TO_ASSUME: ${{inputs.environment == 'nonprod' && secrets.NONPROD_ROLE_ARN || secrets.PROD_ROLE_ARN}}
+  ROLE_TO_ASSUME: ${{ inputs.environment == 'prod' && secrets.PROD_ROLE_ARN || secrets.NONPROD_ROLE_ARN }}
 
 permissions:
   contents: read


### PR DESCRIPTION
I updated the order of the `or` statement in the build and deploy GHA. Now, if the env is 'prod', it uses the prod role to deploy. If the env is anything else, it deploys to nonprod. This means that the default state is to deploy to nonprod, and only the specific input `prod` will trigger a deploy to the production environment. This won't make much difference in practice, as the GHA only allows `prod` and `nonprod` as inputs, but I wanted to be intentional about how the logic is structured.