### PR TITLE
Import collections uses upsert instead of create

### DIFF
--- a/src/controllers/legacy/legacy.controller.spec.ts
+++ b/src/controllers/legacy/legacy.controller.spec.ts
@@ -166,7 +166,7 @@ describe('LegacyController', () => {
         organizationId: 1,
       };
 
-      mockCtx.prisma.copy.create.mockResolvedValue(copy);
+      mockCtx.prisma.copy.upsert.mockResolvedValue(copy);
 
       const bigResponse = await controller.addCopy(1, 1, {
         libraryId: 1,

--- a/src/controllers/legacy/legacy.controller.ts
+++ b/src/controllers/legacy/legacy.controller.ts
@@ -1211,10 +1211,9 @@ export class LegacyController {
     }
 
     const fields = file?.fields as any;
+    console.log(fields);
     this.logger.log(
-      `File input validated; importing collection for orgId=${orgId}, fields=${JSON.stringify(
-        fields,
-      )}`,
+      `File input validated; importing collection for orgId=${orgId}`,
     );
 
     return this.collectionService.importCollection(

--- a/src/controllers/organization/organization.controller.spec.ts
+++ b/src/controllers/organization/organization.controller.spec.ts
@@ -163,7 +163,7 @@ describe('OrganizationController', () => {
 
   describe('createCopy', () => {
     it('should create a copy', async () => {
-      mockCtx.prisma.copy.create.mockResolvedValue({
+      mockCtx.prisma.copy.upsert.mockResolvedValue({
         id: 1,
         gameId: 1,
         winnable: false,
@@ -345,7 +345,7 @@ describe('OrganizationController', () => {
 
       const req = ctx.switchToHttp().getRequest() as fastify.FastifyRequest;
 
-      mockCtx.prisma.copy.create.mockResolvedValue({
+      mockCtx.prisma.copy.upsert.mockResolvedValue({
         id: 1,
         gameId: 1,
         winnable: true,

--- a/src/services/copy/copy.service.spec.ts
+++ b/src/services/copy/copy.service.spec.ts
@@ -46,7 +46,7 @@ describe('CopyService', () => {
 
   describe('createCopy', () => {
     it('should create a copy', async () => {
-      mockCtx.prisma.copy.create.mockResolvedValue({
+      mockCtx.prisma.copy.upsert.mockResolvedValue({
         id: 1,
         gameId: 1,
         dateAdded: new Date(),

--- a/src/services/copy/copy.service.ts
+++ b/src/services/copy/copy.service.ts
@@ -81,9 +81,21 @@ export class CopyService {
     data: Prisma.CopyCreateInput,
     ctx: Context,
   ): Promise<Copy | null> {
-		try {
-			this.logger.log(`Creating copy with data=${JSON.stringify(data)}`);
-      return ctx.prisma.copy.create({ data });
+    try {
+      const copyWhereUniqueInput = {
+
+      }
+      this.logger.log(`Creating copy with data=${JSON.stringify(data)}`);
+      return ctx.prisma.copy.upsert({
+        where: {
+          organizationId_barcodeLabel: {
+            barcodeLabel: data.barcodeLabel,
+            organizationId: Number(data.organization.connect?.id)
+          }
+        },
+        create: data,
+        update: data
+      });
     } catch (ex) {
 			this.logger.error(`Failed to create copy with data=${JSON.stringify(data)}, ex=${ex}`);
       return Promise.reject(ex);


### PR DESCRIPTION
When I tested the library upload, I found that importing copies threw an error if the barcode already exists at the organization level. This is because we were attempting to `create` a record that would violate the unique constraint. If a game with that barcode label already exists, it should update the record instead.